### PR TITLE
Fix: godmt may break because of invalid path on windows.

### DIFF
--- a/internal/utils/Config.go
+++ b/internal/utils/Config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -39,10 +40,10 @@ func ParseApplicationConfig() OperationMode {
 	wantedPath = strings.TrimSuffix(wantedPath, string(os.PathSeparator))
 
 	return OperationMode{
-		WantedPath:    wantedPath,
+		WantedPath:    filepath.Clean(wantedPath),
 		TranslateMode: *translateMode,
 		PreserveNames: *preserveNames,
 		Tree:          *tree,
-		Destination:   *destination,
+		Destination:   filepath.Clean(*destination),
 	}
 }


### PR DESCRIPTION
Closes #12 

The code successfully executed on windows with expected results, without modifying the code. However, transforming the directory paths to a unified format may save us in some cases.